### PR TITLE
Add V8 Support

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -77,7 +77,7 @@ func (e *Encoder) EncodeLength(l uint32) (err error) {
 		_, err = e.w.Write([]byte{byte(l>>8) | rdb14bitLen<<6, byte(l)})
 	default:
 		b := make([]byte, 5)
-		b[0] = rdb32bitLen << 6
+		b[0] = rdb32bitLen
 		binary.BigEndian.PutUint32(b[1:], l)
 		_, err = e.w.Write(b)
 	}


### PR DESCRIPTION
Allows us to use RDB V8 files with cupcake. Should make upgrading to redis 4 possible. 

Some relevant reading on how these changes work: https://rdb.fnordig.de/file_format.html
And the Python implementation that I used for reference when making these changes: https://github.com/sripathikrishnan/redis-rdb-tools/

Tested on all of the sample dumps here: https://github.com/sripathikrishnan/redis-rdb-tools/tree/master/tests/dumps

At some point, it would be good to get this merged upstream as well